### PR TITLE
Support MSK Express clusters + ISO event timestamp

### DIFF
--- a/code/code_stack.py
+++ b/code/code_stack.py
@@ -99,30 +99,42 @@ class CodeStack(Stack):
 import boto3
 import cfnresponse
 def handler(event, context):
+    # Always send a response to CloudFormation; default to FAILED with empty data
+    # so a code path that forgets to send can never hang the stack.
+    result = {}
+    status = cfnresponse.FAILED
     try:
         if event['RequestType'] == 'Delete':
-            return {'Status': 'SUCCESS', 'PhysicalResourceId': 'msk-lookup'}
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, 'msk-lookup')
+            return
         cluster_arn = event['ResourceProperties']['ClusterArn']
         kafka = boto3.client('kafka')
-        response = kafka.describe_cluster_v2(ClusterArn=cluster_arn)
-        cluster = response['ClusterInfo']
-        brokers_response = kafka.get_bootstrap_brokers(ClusterArn=cluster_arn)
-        bootstrap_address = brokers_response.get('BootstrapBrokerStringSaslIam', '')
+        ec2 = boto3.client('ec2')
+        cluster = kafka.describe_cluster_v2(ClusterArn=cluster_arn)['ClusterInfo']
+        bootstrap_address = kafka.get_bootstrap_brokers(ClusterArn=cluster_arn).get('BootstrapBrokerStringSaslIam', '')
+
+        # Serverless and Provisioned/Express expose subnets/SGs in different shapes.
         if 'Serverless' in cluster:
             vpc_config = cluster['Serverless']['VpcConfigs'][0]
-            ec2 = boto3.client('ec2')
-            subnet_response = ec2.describe_subnets(SubnetIds=[vpc_config['SubnetIds'][0]])
-            vpc_id = subnet_response['Subnets'][0]['VpcId']
-            response = {
-                'VpcId': vpc_id,
-                'SubnetId': vpc_config['SubnetIds'][0],
-                'SecurityGroupId': vpc_config['SecurityGroupIds'][0],
-                'BootstrapBrokers': bootstrap_address
-            }
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, response, event['LogicalResourceId'])
+            subnet_ids = vpc_config['SubnetIds']
+            security_group_id = vpc_config['SecurityGroupIds'][0]
+        else:
+            bng = cluster['Provisioned']['BrokerNodeGroupInfo']
+            subnet_ids = bng['ClientSubnets']
+            security_group_id = bng['SecurityGroups'][0]
+
+        vpc_id = ec2.describe_subnets(SubnetIds=[subnet_ids[0]])['Subnets'][0]['VpcId']
+        result = {
+            'VpcId': vpc_id,
+            'SubnetId': subnet_ids[0],
+            'SecurityGroupId': security_group_id,
+            'BootstrapBrokers': bootstrap_address
+        }
+        status = cfnresponse.SUCCESS
     except Exception as e:
-        print("Failed getting bootstrap brokers:", e)
-        cfnresponse.send(event, context, cfnresponse.FAILED, response, event['LogicalResourceId'])
+        print("MSKLookup failed:", e)
+        status = cfnresponse.FAILED
+    cfnresponse.send(event, context, status, result, event.get('LogicalResourceId', 'msk-lookup'))
 """)
         )
         

--- a/code/lambdas/fragmentation_attack/lambda_handler.py
+++ b/code/lambdas/fragmentation_attack/lambda_handler.py
@@ -7,6 +7,7 @@ import random
 import os
 import socket
 import hashlib
+from datetime import datetime, timezone
 
 from kafka import KafkaProducer
 from kafka.errors import KafkaError
@@ -106,7 +107,9 @@ def lambda_handler(event, context):
             "writer_id": f"ENI{generate_8char_hash()}-x{random.randint(1, 5)}",
             "text": generate_fragmentation_text(
                 attacker_ip, target_ip, fragment_id, frag_num * 8, frag_num < 29
-            )
+            ),
+            # ISO 8601 event timestamp for hourly time-based Iceberg partitioning
+            "event_time_iso": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         }
         
         producer.send(topic, key=str(frag_num), value=data)

--- a/normal-events-producer/normal_events_producer.py
+++ b/normal-events-producer/normal_events_producer.py
@@ -7,6 +7,7 @@ import os
 import socket
 import hashlib
 import time
+from datetime import datetime, timezone
 
 from faker import Faker
 from faker.providers import internet
@@ -87,7 +88,9 @@ def produce_normal_events():
             "packets": random.randint(100, 500),
             "bytes": random.randint(64, 1500),
             "writer_id": f"ENI-{generate_8char_hash()}-x{random.randint(1, 5)}",
-            "text": f"Normal traffic from {fake.ipv4_private()} to {random.choice(internal_ips)}"
+            "text": f"Normal traffic from {fake.ipv4_private()} to {random.choice(internal_ips)}",
+            # ISO 8601 event timestamp for hourly time-based Iceberg partitioning
+            "event_time_iso": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         }
         
         producer.send(topic, key=str(random.randint(1, 10000)), value=data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- MSKLookup custom resource: handle Provisioned/Express clusters (read subnets/SGs from BrokerNodeGroupInfo), and always send a cfnresponse so the resource can never silently hang the stack on a non-Serverless cluster.
- normal_events_producer + fragmentation_attack lambda: add event_time_iso (ISO 8601) field to support hourly time-based Iceberg partitioning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
